### PR TITLE
Update PBD. camera up vector & mouse drag vertex

### DIFF
--- a/OpenCloth_PositionBasedDynamics/OpenCloth_PositionBasedDynamics/main.cpp
+++ b/OpenCloth_PositionBasedDynamics/OpenCloth_PositionBasedDynamics/main.cpp
@@ -258,11 +258,14 @@ void OnMouseMove(int x, int y)
 		
 		 
 		V[selected_index] = glm::vec3(0);
-		X[selected_index].x += Right[0]*valX ;
-		float newValue = X[selected_index].y+Up[1]*valY;
-		if(newValue>0)
-			X[selected_index].y = newValue;
-		X[selected_index].z += Right[2]*valX + Up[2]*valY;		
+		//X[selected_index].x += Right[0]*valX ;
+		//float newValue = X[selected_index].y+Up[1]*valY;
+		//if(newValue>0)
+		//	X[selected_index].y = newValue;
+		//X[selected_index].z += Right[2]*valX + Up[2]*valY;
+		X[selected_index].x += Right[0] * valX + Up[0] * valY;
+		X[selected_index].y += Right[1] * valX + Up[1] * valY;
+		X[selected_index].z += Right[2] * valX + Up[2] * valY;
 	}
 	oldX = x; 
 	oldY = y; 
@@ -510,7 +513,14 @@ void OnRender() {
 	viewDir.x = (float)-MV[2];
 	viewDir.y = (float)-MV[6];
 	viewDir.z = (float)-MV[10];
-	Right = glm::cross(viewDir, Up);
+	//Right = glm::cross(viewDir, Up);
+	Right.x = (float)MV[0];
+	Right.y = (float)MV[4];
+	Right.z = (float)MV[8];
+	
+	Up.x = (float)MV[1];
+	Up.y = (float)MV[5];
+	Up.z = (float)MV[9];
 
 	//draw grid
 	DrawGrid();
@@ -756,7 +766,7 @@ void UpdateBendingConstraint(int index) {
 		d=1.0; //d = clamp(d,-1.0,1.0);
 	
 	//in both case sqrt(1-d*d) will be zero and nothing will be done.
-	//0° case, the triangles are facing in the opposite direction, folded together.
+	//0?case, the triangles are facing in the opposite direction, folded together.
 	if(d == -1.0){ 
 	   phi = PI;  //acos(-1.0) == PI
        if(phi == phi0[index]) 
@@ -773,7 +783,7 @@ void UpdateBendingConstraint(int index) {
 
 	  return;
 	}
-	if(d == 1.0){ //180° case, the triangles are planar
+	if(d == 1.0){ //180?case, the triangles are planar
 		phi = 0.0;  //acos(1.0) == 0.0
         if(phi == phi0[index]) 
 			return; //nothing to do 


### PR DESCRIPTION
 I am a graduate student studying clothsimulation. I am learning a lot through your opencloth project. So thank you very much.
  While studying PBD part, I confirmed that mouse drag of vertex does not work properly when I rotate the camera more than 180 degrees. I have determined that the cause is that the camera up vector is not updating properly. So I modified it to update the up vector of the camera. I also made some modifications to ensure that the mouse drag of the vertex is correct using the vector components of the camera.
 Of course, it is not a big problem, so I have fully understood the part of the programmer who wrote the code. However, I am sending this PR because I think that the following modifications will help others to understand the camera part.
  Thanks to your open source, I am very grateful for your help so much. Have a nice day.

From. OSgood 
My mail: osgood@graphics.snu.ac.kr or ckdwls93@gmail.com