### PR TITLE
Fix VS 2015/2017/2019 compile errors.

### DIFF
--- a/OpenCloth_CoRotated_Linear_FEM/OpenCloth_CoRotated_Linear_FEM/main.cpp
+++ b/OpenCloth_CoRotated_Linear_FEM/OpenCloth_CoRotated_Linear_FEM/main.cpp
@@ -32,7 +32,7 @@
 #include <vector>
 #include <map>
 #include <glm/glm.hpp>
-
+#include <algorithm>
 
 #pragma comment(lib, "glew32.lib")
 
@@ -126,7 +126,7 @@ vector<glm::vec3> b;
 
 //For Conjugate Gradient 
 vector<glm::vec3> residual;
-vector<glm::vec3> prev;
+vector<glm::vec3> previous;
 vector<glm::vec3> update;
  
 float tiny      = 1e-010f;       // TODO: Should be user controllable
@@ -438,7 +438,7 @@ void InitGL() {
 	F0.resize(total_points); 
 	residual.resize(total_points);
 	update.resize(total_points);
-	prev.resize(total_points);
+	previous.resize(total_points);
 
 	//fill in V
 	memset(&(V[0].x),0,total_points*sizeof(glm::vec3));
@@ -565,7 +565,7 @@ void OnShutdown() {
 	F0.clear();
 	b.clear();
 	residual.clear();
-	prev.clear();
+	previous.clear();
 	update.clear();
 }
 
@@ -851,13 +851,13 @@ void ConjugateGradientSolver(float dt) {
 			float v_jx = V[j].x;	
 			float v_jy = V[j].y;
 			float v_jz = V[j].z;
-			glm::vec3 prod = glm::vec3(	A_ij[0][0] * v_jx+A_ij[0][1] * v_jy+A_ij[0][2] * v_jz, //A_ij * prev[j]
+			glm::vec3 prod = glm::vec3(	A_ij[0][0] * v_jx+A_ij[0][1] * v_jy+A_ij[0][2] * v_jz, //A_ij * previous[j]
 										A_ij[1][0] * v_jx+A_ij[1][1] * v_jy+A_ij[1][2] * v_jz,			
 										A_ij[2][0] * v_jx+A_ij[2][1] * v_jy+A_ij[2][2] * v_jz);
 			residual[k] -= prod;//  A_ij * v_j;
 			
 		}
-		prev[k]=residual[k];
+		previous[k]=residual[k];
 	}
 	
 	for(int i=0;i<i_max;i++) {
@@ -876,17 +876,17 @@ void ConjugateGradientSolver(float dt) {
 			for (matrix_iterator A = Abegin; A != Aend;++A) {
 				unsigned int j   = A->first;
 				glm::mat3& A_ij  = A->second;
-				float prevx = prev[j].x;
-				float prevy = prev[j].y;
-				float prevz = prev[j].z;
-				glm::vec3 prod = glm::vec3(	A_ij[0][0] * prevx+A_ij[0][1] * prevy+A_ij[0][2] * prevz, //A_ij * prev[j]
+				float prevx = previous[j].x;
+				float prevy = previous[j].y;
+				float prevz = previous[j].z;
+				glm::vec3 prod = glm::vec3(	A_ij[0][0] * prevx+A_ij[0][1] * prevy+A_ij[0][2] * prevz, //A_ij * previous[j]
 											A_ij[1][0] * prevx+A_ij[1][1] * prevy+A_ij[1][2] * prevz,			
 											A_ij[2][0] * prevx+A_ij[2][1] * prevy+A_ij[2][2] * prevz);
-				update[k] += prod;//A_ij*prev[j];
+				update[k] += prod;//A_ij*previous[j];
 				 
 			}
 			d += glm::dot(residual[k],residual[k]);
-			d2 += glm::dot(prev[k],update[k]);
+			d2 += glm::dot(previous[k],update[k]);
 		} 
 		
 		if(fabs(d2)<tiny)
@@ -900,7 +900,7 @@ void ConjugateGradientSolver(float dt) {
 			if(IsFixed[k])
 				continue;
 
-			V[k] += prev[k]* d3;
+			V[k] += previous[k]* d3;
 			residual[k] -= update[k]*d3;
 			d1 += glm::dot(residual[k],residual[k]);
 		}
@@ -916,7 +916,7 @@ void ConjugateGradientSolver(float dt) {
 		for(size_t k=0;k<total_points;k++) {
 			if(IsFixed[k])
 				continue;
-			prev[k] = residual[k] + prev[k]*d4;
+			previous[k] = residual[k] + previous[k]*d4;
 		}		
 	}	
 }

--- a/OpenCloth_ExplicitEuler/OpenCloth_ExplicitEuler/main.cpp
+++ b/OpenCloth_ExplicitEuler/OpenCloth_ExplicitEuler/main.cpp
@@ -58,8 +58,8 @@ const int width = 1024, height = 1024;
 
 int numX = 20, numY=20;
 const size_t total_points = (numX+1)*(numY+1);
-int size = 4;
-float hsize = size/2.0f;
+float fullsize = 4.0f;
+float halfsize = fullsize/2.0f;
 
 float timeStep =  1/60.0f;
 float currentTime = 0;
@@ -262,7 +262,7 @@ void InitGL() {
 	//fill in X
 	for( j=0;j<v;j++) {
 		for( i=0;i<u;i++) {
-			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* hsize, size+1, ((float(j)/(v-1) )* size));
+			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* halfsize, fullsize+1, ((float(j)/(v-1) )* fullsize));
 		}
 	}
 

--- a/OpenCloth_ExplicitEuler_TextureMapped_Lit/OpenCloth_ExplicitEuler_TextureMapped_Lit/main.cpp
+++ b/OpenCloth_ExplicitEuler_TextureMapped_Lit/OpenCloth_ExplicitEuler_TextureMapped_Lit/main.cpp
@@ -58,8 +58,8 @@ const int width = 1024, height = 1024;
 
 int numX = 20, numY=20;
 const size_t total_points = (numX+1)*(numY+1);
-int size = 4;
-float hsize = size/2.0f;
+float fullsize = 4.0f;
+float halfsize = fullsize/2.0f;
 
 float timeStep =  1/60.0f;
 float currentTime = 0;
@@ -302,7 +302,7 @@ void InitGL() {
 	//fill in X
 	for( j=0;j<v;j++) {
 		for( i=0;i<u;i++) {
-			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* hsize, size+1, ((float(j)/(v-1) )* size));
+			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* halfsize, fullsize+1, ((float(j)/(v-1) )* fullsize));
 		}
 	}
 
@@ -331,8 +331,8 @@ void InitGL() {
 	 
 	for(size_t i=0;i<total_points;i++) {
 		Vertex& t = vertices[i];
-		t.uv.x = (float(X[i].x+hsize)/ float(size)) *10.0f;	
-		t.uv.y = (float(X[i].z)/float(size)) *10.0f;	 
+		t.uv.x = (float(X[i].x+halfsize)/ fullsize) *10.0f;	
+		t.uv.y = (float(X[i].z)/fullsize) *10.0f; 
 	}
 	glPointSize(5);
 

--- a/OpenCloth_ExplicitEuler_Wind/OpenCloth_ExplicitEuler_Wind/main.cpp
+++ b/OpenCloth_ExplicitEuler_Wind/OpenCloth_ExplicitEuler_Wind/main.cpp
@@ -36,8 +36,8 @@ const int width = 1024, height = 1024;
  
 int numX = 20, numY=20;
 const size_t total_points = (numX+1)*(numY+1);
-int size = 4;
-float hsize = size/2.0f;
+float fullsize = 4.0f;
+float halfsize = fullsize/2.0f;
 
 float timeStep =  1/60.0f;
 float currentTime = 0;
@@ -243,7 +243,7 @@ void InitGL() {
 	//fill in X
 	for( j=0;j<v;j++) {		 
 		for( i=0;i<u;i++) {	 
-			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* hsize, size+1, ((float(j)/(v-1) )* size));
+			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* halfsize, fullsize+1, ((float(j)/(v-1) )* fullsize));
 		}
 	}
 
@@ -613,7 +613,7 @@ void OnIdle() {
 }
 
 void StepPhysics(float dt ) {
-	srand(time(NULL));
+	srand((unsigned int)time(NULL));
 	float rx = (float(rand())/RAND_MAX)*2-1.0f;
 	float ry = (float(rand())/RAND_MAX)*2-1.0f;
 	float rz = (float(rand())/RAND_MAX)*2-1.0f;

--- a/OpenCloth_IMEX/OpenCloth_IMEX/main.cpp
+++ b/OpenCloth_IMEX/OpenCloth_IMEX/main.cpp
@@ -40,8 +40,8 @@ float frameTime =0 ;
 
 int numX = 20, numY=20;
 const size_t total_points = (numX+1)*(numY+1);
-int size = 4;
-float hsize = size/2.0f;
+float fullsize = 4.0f;
+float halfsize = fullsize/2.0f;
 
 float timeStep =  1/60.0f;
 float currentTime = 0;
@@ -238,7 +238,7 @@ void InitGL() {
 	//fill in positions
 	for( j=0;j<=numY;j++) {		 
 		for( i=0;i<=numX;i++) {	 
-			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* hsize, size+1, ((float(j)/(v-1) )* size));
+			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* halfsize, fullsize+1, ((float(j)/(v-1) )* fullsize));
 		}
 	}
 

--- a/OpenCloth_Implicit/OpenCloth_Implicit/main.cpp
+++ b/OpenCloth_Implicit/OpenCloth_Implicit/main.cpp
@@ -59,8 +59,8 @@ const int width = 1024, height = 1024;
 
 int numX = 20, numY=20;
 const size_t total_points = (numX+1)*(numY+1);
-int size = 4;
-float hsize = size/2.0f;
+float fullsize = 4.0f;
+float halfsize = fullsize/2.0f;
 
 float timeStep =  5/60.0f;
 float currentTime = 0;
@@ -497,7 +497,7 @@ void InitGL() {
 	//fill in X
 	for( j=0;j<=numY;j++) {
 		for( i=0;i<=numX;i++) {
-			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* hsize, size+1, ((float(j)/(v-1) )* size));
+			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* halfsize, fullsize+1, ((float(j)/(v-1) )* fullsize));
 		}
 	}
 

--- a/OpenCloth_ImplicitEuler/OpenCloth_ImplicitEuler/main.cpp
+++ b/OpenCloth_ImplicitEuler/OpenCloth_ImplicitEuler/main.cpp
@@ -58,8 +58,8 @@ const int width = 1024, height = 1024;
 
 int numX = 20, numY=20;
 const size_t total_points = (numX+1)*(numY+1);
-int size = 4;
-float hsize = size/2.0f;
+float fullsize = 4.0f;
+float halfsize = fullsize/2.0f;
 
 char info[MAX_PATH]={0};
 
@@ -461,7 +461,7 @@ void InitGL() {
 	//fill in positions
 	for( j=0;j<=numY;j++) {
 		for( i=0;i<=numX;i++) {
-			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* hsize, size+1, ((float(j)/(v-1) )* size));
+			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* halfsize, fullsize+1, ((float(j)/(v-1) )* fullsize));
 		}
 	}
 

--- a/OpenCloth_MeshlessFEM/OpenCloth_MeshlessFEM/main.cpp
+++ b/OpenCloth_MeshlessFEM/OpenCloth_MeshlessFEM/main.cpp
@@ -35,6 +35,7 @@
 #include <GL/glut.h>
 #include <vector>
 #define _USE_MATH_DEFINES
+#include <math.h>
 
 #include <glm/glm.hpp>
 

--- a/OpenCloth_PositionBasedDynamics/OpenCloth_PositionBasedDynamics/main.cpp
+++ b/OpenCloth_PositionBasedDynamics/OpenCloth_PositionBasedDynamics/main.cpp
@@ -66,8 +66,8 @@ const int width = 1024, height = 1024;
  
 int numX = 20, numY=20; //these ar the number of quads
 const size_t total_points = (numX+1)*(numY+1);
-int size = 4;
-float hsize = size/2.0f;
+float fullsize = 4.0f;
+float halfsize = fullsize/2.0f;
 
 char info[MAX_PATH]={0};
 
@@ -337,7 +337,7 @@ void InitGL() {
 	//fill in positions
 	for(int j=0;j<=numY;j++) {		 
 		for(int i=0;i<=numX;i++) {	 
-			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* hsize, size+1, ((float(j)/(v-1) )* size));
+			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* halfsize, fullsize+1, ((float(j)/(v-1) )* fullsize));
 		}
 	}
 

--- a/OpenCloth_SemiImplicit/OpenCloth_SemiImplicit/main.cpp
+++ b/OpenCloth_SemiImplicit/OpenCloth_SemiImplicit/main.cpp
@@ -39,8 +39,8 @@ float frameTime =0 ;
 
 int numX = 20, numY=20;
 const size_t total_points = (numX+1)*(numY+1);
-int size = 4;
-float hsize = size/2.0f;
+float fullsize = 4.0f;
+float halfsize = fullsize/2.0f;
 
 float timeStep =  1/60.0f;
 float currentTime = 0;
@@ -228,7 +228,7 @@ void InitGL() {
 	//fill in positions
 	for( j=0;j<=numY;j++) {		 
 		for( i=0;i<=numX;i++) {	 
-			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* hsize, size+1, ((float(j)/(v-1) )* size));
+			X[count++] = glm::vec3( ((float(i)/(u-1)) *2-1)* halfsize, fullsize+1, ((float(j)/(v-1) )* fullsize));
 		}
 	}
 

--- a/OpenCloth_Verlet/OpenCloth_Verlet/main.cpp
+++ b/OpenCloth_Verlet/OpenCloth_Verlet/main.cpp
@@ -58,8 +58,8 @@ const int width = 1024, height = 1024;
 
 int numX = 20, numY=20;
 const size_t total_points = (numX+1)*(numY+1);
-int size = 4;
-float hsize = size/2.0f;
+float fullsize = 4.0f;
+float halfsize = fullsize/2.0f;
 
 
 int selected_index = -1;
@@ -253,7 +253,7 @@ void InitGL() {
 	//fill in positions
 	for( j=0;j<=numY;j++) {
 		for( i=0;i<=numX;i++) {
-			X[count] = glm::vec3( ((float(i)/(u-1)) *2-1)* hsize, size+1, ((float(j)/(v-1) )* size));
+			X[count] = glm::vec3( ((float(i)/(u-1)) *2-1)* halfsize, fullsize+1, ((float(j)/(v-1) )* fullsize));
 			X_last[count] = X[count];
 			count++;
 		}

--- a/OpenCloth_Verlet_GLSL(GPGPU)/OpenCloth_Verlet_GLSL(GPGPU)/main.cpp
+++ b/OpenCloth_Verlet_GLSL(GPGPU)/OpenCloth_Verlet_GLSL(GPGPU)/main.cpp
@@ -128,7 +128,7 @@ GLuint vboID;
 GLenum mrt[] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1};
 
 
-float* data[2];
+float* dataX[2];
 size_t i=0;
 GLfloat vRed[4]={1,0,0,1};
 GLfloat vWhite[4]={1,1,1,1};
@@ -138,8 +138,8 @@ glm::vec3 vec3(glm::vec4 v) {
 }
 
 void InitFBO() { 
-	data[0] = &X[0].x;
-	data[1] = &X_last[0].x;
+	dataX[0] = &X[0].x;
+	dataX[1] = &X_last[0].x;
 	glGenTextures(4, attachID);
 	glGenFramebuffers(2, fboID);
 	
@@ -155,7 +155,7 @@ void InitFBO() {
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
-			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, texture_size_x, texture_size_y, 0, GL_RGBA, GL_FLOAT, data[i]); // NULL = Empty texture
+			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, texture_size_x, texture_size_y, 0, GL_RGBA, GL_FLOAT, dataX[i]); // NULL = Empty texture
 			
 			glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, mrt[i],	GL_TEXTURE_2D, attachID[i+2*j], 0);			 
 			printf(" %d ", i+ 2*j);

--- a/OpenCloth_WebGL/WebGLOpenCloth.html
+++ b/OpenCloth_WebGL/WebGLOpenCloth.html
@@ -92,8 +92,8 @@
 		oldY = 0;
 		state = -1;
 		D2R   = 0.0174532925199433;
-		size = 4; //world space size of cloth
-        hsize = size/2;
+		fullsize = 4; //world space size of cloth
+        halfsize = fullsize/2;
 		u     = numX +1;
 		v     = numY +1;
 
@@ -144,7 +144,7 @@
        	//Fill in vertices of cloth mesh
         for(var j=0;j<v;j++) {
 			for(var i=0;i<u;i++) {
-			    var tmp = new THREE.Vector3( ((i/(u-1)) *2.0-1.)* hsize,size+1, ((j/(v-1.0) )* size));
+			    var tmp = new THREE.Vector3( ((i/(u-1)) *2.0-1.)* halfsize,fullsize+1, ((j/(v-1.0) )* fullsize));
 				F.push(new THREE.Vector3(0,0,0));
 				V.push(new THREE.Vector3(0,0,0));
 			    geometry.vertices.push(tmp);

--- a/OpenCloth_WebGL/WebGLOpenClothTextured.html
+++ b/OpenCloth_WebGL/WebGLOpenClothTextured.html
@@ -88,8 +88,8 @@
 			oldY = 0;
 			state = -1;
 			D2R = 0.0174532925199433;
-			size = 4; //world space size of cloth
-	        hsize = size/2;
+			fullsize = 4; //world space size of cloth
+	        halfsize = fullsize/2;
 			u = numX +1;
 			v = numY +1;
 
@@ -137,7 +137,7 @@
 			//Fill in vertices of cloth mesh
 			for(var j=0;j<v;j++) {
 				for(var i=0;i<u;i++) {
-				    var tmp = new THREE.Vector3( ((i/(u-1)) *2.0-1.)* hsize,size+1, ((j/(v-1.0) )* size));
+				    var tmp = new THREE.Vector3( ((i/(u-1)) *2.0-1.)* halfsize,fullsize+1, ((j/(v-1.0) )* fullsize));
 				    tmp.uv = new THREE.Vector2( 	i / (u-1), 	1.0-j / (v-1) );
 
 					F.push(new THREE.Vector3(0,0,0));


### PR DESCRIPTION
Compiling any of the current Open Cloth projects with Visual Studio versions 2015, 2017, or 2019 will fail with errors.

The variables 'size', 'prev', and 'data' cause 'ambiguous symbols' errors, and should not be used.

Changed 'size' to be 'fullsize', also changed 'hsize' to 'halfsize', just because it makes more sense.  Also updated the WebGL programs with the same variable names, to be consistent.  Changed 'prev' to 'previous'.  Changed 'data' to 'dataX'.

In MeshlessFEM, added '#include <math.h>', so the compiler could find M_PI.
In CoRotated Linear FEM, added '#include <algorithm>', so the compiler could find 'min'.

The above changes were tested using VS 2008, 2010, 2012, 2015, 2017, and 2019.